### PR TITLE
Update sample code to work with latest aws-crt-client SDK release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <dependency><!-- This controls the version for the rest of the SDK: services, logging, request signing -->
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.14.13</version>
+                <version>2.20.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-            <version>2.17.69-PREVIEW</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/example/AwsKmsPqTlsExample.java
+++ b/src/main/java/com/example/AwsKmsPqTlsExample.java
@@ -60,23 +60,13 @@ public class AwsKmsPqTlsExample {
     private static final int AES_KEY_SIZE_BYTES = 256 / 8;
 
     public static void main(String[] args) throws Exception {
-        TlsCipherPreference tlsCipherPreference = TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05;
-
         /*
-         * Check preconditions before continuing. The AWS CRT supports hybrid post-quantum TLS on Linux systems only.
-         */
-        if (tlsCipherPreference.isSupported()) {
-            LOG.info(() -> "Hybrid post-quantum ciphers are supported and will be used");
-        } else {
-            throw new UnsupportedOperationException("Hybrid post-quantum cipher suites are supported only on Linux systems");
-        }
-
-        LOG.info(() -> "Using TLS Cipher Preference: " + tlsCipherPreference.name());
-        /*
-         * Set up a PQ TLS HTTP client that will be used in the rest of the example.
+         * Set up a PQ TLS HTTP client that will be used in the rest of the example. This will optimistically enable
+         * hybrid post-quantum TLS if post-quantum algorithms are supported on the current platform, otherwise the
+         * default TLS configuration will be used.
          */
         SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
-                .tlsCipherPreference(tlsCipherPreference)
+                .postQuantumTlsEnabled(true)
                 .build();
         /*
          * Set up a Java SDK 2.0 KMS Client which will use hybrid post-quantum TLS for all connections to KMS.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Updates KMS Post Quantum TLS sample code to use the GA release of `aws-crt-client` now available in Java SDK v2.20.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
