### PR TITLE
Update KMS PQ TLS sample code to use ML-KEM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <dependency><!-- This controls the version for the rest of the SDK: services, logging, request signing -->
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.20.0</version>
+                <version>2.30.22</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Updates the [AWS SDK version to v2.30.22 that supports ML-KEM](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.30.22). 

Confirmed with tcpdump packet capture that X25519MLKEM768 is negotiated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
